### PR TITLE
Add "hex" badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ExUnitParameterize
 ![tests](https://github.com/rciorba/yapara/actions/workflows/test.yaml/badge.svg?branch=master)
+[![](https://img.shields.io/hexpm/v/ex_unit_parameterize.svg?style=flat)](https://hex.pm/packages/ex_unit_parameterize)
 
 Parameterized tests for ExUnit.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:ex_unit_parameterize, "~> 0.1.0"}
+    {:ex_unit_parameterize, "~> 0.1.0-alpha.4"}
   ]
 end
 ```


### PR DESCRIPTION
1. "Hex" badge has been added to README.md
2. It looks well and the link go to [hex.pm package statistic](https://hex.pm/packages/ex_unit_parameterize)
3. We can see package current version

Screenshot:
![badge_screen](https://github.com/user-attachments/assets/a24c4a41-0d6b-48f5-bca8-945aea3fd9c6)

All `GitHub actions`  was passed
